### PR TITLE
Ruby 1.8 compat

### DIFF
--- a/lib/net/ber/ber_parser.rb
+++ b/lib/net/ber/ber_parser.rb
@@ -165,4 +165,9 @@ module Net::BER::BERParser
 
     parse_ber_object(syntax, id, data)
   end
+
+  # Ruby 1.8.x compatibility - prior to 1.9, getbyte and getc were equivalent
+  def getbyte
+    getc
+  end unless self.methods.include? :getbyte
 end

--- a/lib/net/ber/core_ext/fixnum.rb
+++ b/lib/net/ber/core_ext/fixnum.rb
@@ -1,4 +1,11 @@
 module Net::BER::Extensions::Fixnum
+
+  ##
+  # Define ord for ruby 1.8
+  def ord
+    self
+  end unless Fixnum.methods.include? :ord
+
   ##
   # Converts the fixnum to BER format.
   def to_ber


### PR DESCRIPTION
Hi,
we've been running this patch for a few days and it appears to be all that's required for use with ruby 1.8.6; we're using it against ActiveDirectory for user authentication.
