### PR TITLE
Auto-escaped convenience methods for filters

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -13,7 +13,6 @@ end
 require 'socket'
 
 require 'net/ber'
-require 'net/ldap/dn'
 require 'net/ldap/pdu'
 require 'net/ldap/filter'
 require 'net/ldap/dataset'

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -13,6 +13,7 @@ end
 require 'socket'
 
 require 'net/ber'
+require 'net/ldap/dn'
 require 'net/ldap/pdu'
 require 'net/ldap/filter'
 require 'net/ldap/dataset'

--- a/lib/net/ldap/dn.rb
+++ b/lib/net/ldap/dn.rb
@@ -1,0 +1,88 @@
+class Net::LDAP::DN
+  ##
+  # Initialize a DN, escaping as required. Pass in attributes in name/value
+  # pairs. If there is a left over argument, it will be appended to the dn
+  # without escaping (useful for a base string).
+  # 
+  # Most uses of this class will be to escape a DN, rather than to parse it,
+  # so storing the dn as an escaped String and parsing parts as required with
+  # a state machine seems sensible.
+  def initialize(*args)
+    buffer = StringIO.new
+
+    args.each_index do |index|
+      buffer << "=" if index % 2 == 1
+      buffer << "," if index % 2 == 0 && index != 0
+
+      if index < args.length - 1 || index % 2 == 1
+        buffer << Net::LDAP::DN.escape(args[index])
+      else
+        buffer << args[index]
+      end
+    end
+
+    @dn = buffer.string
+  end
+
+  ##
+  # Parse the DN into key/value pairs.
+  def each
+    state = :key
+    key = StringIO.new
+    value = StringIO.new
+    hex_buffer = ""
+
+    @dn.each_char do |char|
+      case state
+        when :key then case char
+          when '\\' then state = :key_escape
+          when '=' then state = :value
+          else key << char
+        end
+        when :value then case char
+          when '\\' then state = :value_escape
+          when ',' then state = :key; yield key.string, value.string; key = StringIO.new; value = StringIO.new;
+          else value << char
+        end
+        when :key_escape then case char
+          when "0".."9","a".."f","A".."F" then state = :key_escape_hex; hex_buffer = char
+          else state = :key; key << char
+        end
+        when :key_escape_hex then case char
+          when "0".."9","a".."f","A".."F" then state = :key; key << "#{hex_buffer}#{char}".to_i(16).chr
+          else raise "DN badly formed"
+        end
+        when :value_escape then case char
+          when "0".."9","a".."f","A".."F" then state = :value_escape_hex; hex_buffer = char
+          else state = :value; value << char
+        end
+        when :value_escape_hex then case char
+          when "0".."9","a".."f","A".."F" then state = :value; value << "#{hex_buffer}#{char}".to_i(16).chr
+          else raise "DN badly formed"
+        end
+      end
+    end
+    # Last pair
+    yield key.string, value.string
+  end
+
+  ##
+  # Return the DN as an escaped string.
+  def to_s
+    @dn
+  end
+
+  ##
+  # Returns the DN as an array in the form expected by the constructor.
+  def to_a
+    a = []
+    self.each { |key, value| a << key << value }
+    a
+  end
+
+  ##
+  # Escape a string for use in an LDAP dn
+  def self.escape(value)
+    value.gsub(/[,=+<>#;\\"]/) {|s| "\\#{s}" } 
+  end
+end

--- a/lib/net/ldap/dn.rb
+++ b/lib/net/ldap/dn.rb
@@ -56,23 +56,35 @@ class Net::LDAP::DN
         end
         when :value then case char
           when '\\' then state = :value_escape
-          when ',' then state = :key; yield key.string, value.string; key = StringIO.new; value = StringIO.new;
+          when ',' then
+            state = :key
+            yield key.string, value.string
+            key = StringIO.new
+            value = StringIO.new;
           else value << char
         end
         when :key_escape then case char
-          when "0".."9","a".."f","A".."F" then state = :key_escape_hex; hex_buffer = char
+          when "0".."9","a".."f","A".."F" then
+            state = :key_escape_hex;
+            hex_buffer = char
           else state = :key; key << char
         end
         when :key_escape_hex then case char
-          when "0".."9","a".."f","A".."F" then state = :key; key << "#{hex_buffer}#{char}".to_i(16).chr
+          when "0".."9","a".."f","A".."F" then
+            state = :key
+            key << "#{hex_buffer}#{char}".to_i(16).chr
           else raise "DN badly formed"
         end
         when :value_escape then case char
-          when "0".."9","a".."f","A".."F" then state = :value_escape_hex; hex_buffer = char
+          when "0".."9","a".."f","A".."F" then
+            state = :value_escape_hex
+            hex_buffer = char
           else state = :value; value << char
         end
         when :value_escape_hex then case char
-          when "0".."9","a".."f","A".."F" then state = :value; value << "#{hex_buffer}#{char}".to_i(16).chr
+          when "0".."9","a".."f","A".."F" then
+            state = :value
+            value << "#{hex_buffer}#{char}".to_i(16).chr
           else raise "DN badly formed"
         end
       end

--- a/lib/net/ldap/dn.rb
+++ b/lib/net/ldap/dn.rb
@@ -64,25 +64,25 @@ class Net::LDAP::DN
           else value << char
         end
         when :key_escape then case char
-          when "0".."9","a".."f","A".."F" then
+          when "0".."9", "a".."f", "A".."F" then
             state = :key_escape_hex;
             hex_buffer = char
           else state = :key; key << char
         end
         when :key_escape_hex then case char
-          when "0".."9","a".."f","A".."F" then
+          when "0".."9", "a".."f", "A".."F" then
             state = :key
             key << "#{hex_buffer}#{char}".to_i(16).chr
           else raise "DN badly formed"
         end
         when :value_escape then case char
-          when "0".."9","a".."f","A".."F" then
+          when "0".."9", "a".."f", "A".."F" then
             state = :value_escape_hex
             hex_buffer = char
           else state = :value; value << char
         end
         when :value_escape_hex then case char
-          when "0".."9","a".."f","A".."F" then
+          when "0".."9", "a".."f", "A".."F" then
             state = :value
             value << "#{hex_buffer}#{char}".to_i(16).chr
           else raise "DN badly formed"

--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -79,6 +79,8 @@ class Net::LDAP::Filter
     # <tt>mail</tt> value containing the substring "anderson":
     #
     #   f = Net::LDAP::Filter.eq("mail", "*anderson*")
+    #
+    # This filter does not perform any escaping
     def eq(attribute, value)
       new(:eq, attribute, value)
     end
@@ -136,8 +138,42 @@ class Net::LDAP::Filter
     # Creates a Filter object indicating that a particular attribute value
     # is either not present or does not match a particular string; see
     # Filter::eq for more information.
+    #
+    # This filter does not perform any escaping
     def ne(attribute, value)
       new(:ne, attribute, value)
+    end
+
+    ##
+    # Creates a Filter object indicating that the value of a particular
+    # attribute must match a particular string. The attribute value is
+    # escaped, so the "*" character is interpreted literally.
+    def equals(attribute, value)
+      new(:eq, attribute, escape(value))
+    end
+
+    ##
+    # Creates a Filter object indicating that the value of a particular
+    # attribute must begin with a particular string. The attribute value is
+    # escaped, so the "*" character is interpreted literally.
+    def begins(attribute, value)
+      new(:eq, attribute, escape(value) + "*")
+    end
+
+    ##
+    # Creates a Filter object indicating that the value of a particular
+    # attribute must end with a particular string. The attribute value is
+    # escaped, so the "*" character is interpreted literally.
+    def ends(attribute, value)
+      new(:eq, attribute, "*" + escape(value))
+    end
+
+    ##
+    # Creates a Filter object indicating that the value of a particular
+    # attribute must contain a particular string. The attribute value is
+    # escaped, so the "*" character is interpreted literally.
+    def contains(attribute, value)
+      new(:eq, attribute, "*" + escape(value) + "*")
     end
 
     ##
@@ -206,6 +242,12 @@ class Net::LDAP::Filter
     end
     alias_method :present, :present?
     alias_method :pres, :present?
+
+    ##
+    # Escape a string for use in an LDAP filter
+    def escape(string)
+      string.gsub(/[\*\(\)\\\0]/) {|s| sprintf("\\%02x", s[0]) } 
+    end
 
     ##
     # Converts an LDAP search filter in BER format to an Net::LDAP::Filter

--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -249,12 +249,11 @@ class Net::LDAP::Filter
     # string using a single backslash ('\') as escape. 
     #
     ESCAPES = {
-      '!' => '21', # EXCLAMATION    = %x21 ; exclamation mark ("!")
-      '&' => '26', # AMPERSAND      = %x26 ; ampersand (or AND symbol) ("&")
-      '*' => '2A', # ASTERISK       = %x2A ; asterisk ("*")
-      ':' => '3A', # COLON          = %x3A ; colon (":")
-      '|' => '7C', # VERTBAR        = %x7C ; vertical bar (or pipe) ("|")
-      '~' => '7E', # TILDE          = %x7E ; tilde ("~")
+      '\0' => '00', # NUL            = %x00 ; null character
+      '*'  => '2A', # ASTERISK       = %x2A ; asterisk ("*")
+      '('  => '28', # LPARENS        = %x28 ; left parenthesis ("(")
+      ')'  => '29', # RPARENS        = %x29 ; right parenthesis (")")
+      '\\' => '5C', # ESC            = %x5C ; esc (or backslash) ("\")
     }
     # Compiled character class regexp using the keys from the above hash. 
     ESCAPE_RE = Regexp.new(

--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -269,12 +269,6 @@ class Net::LDAP::Filter
     end
 
     ##
-    # Escape a string for use in an LDAP filter
-    def escape(string)
-      string.gsub(/[\*\(\)\\\0]/) {|s| sprintf("\\%02x", s[0]) } 
-    end
-
-    ##
     # Converts an LDAP search filter in BER format to an Net::LDAP::Filter
     # object. The incoming BER object most likely came to us by parsing an
     # LDAP searchRequest PDU. See also the comments under #to_ber, including

--- a/test/test_dn.rb
+++ b/test/test_dn.rb
@@ -1,0 +1,14 @@
+require 'common'
+
+class TestDN < Test::Unit::TestCase
+  DN = Net::LDAP::DN
+
+  def test_to_s
+    assert_equal("cn=Jam\\<m\\>y,ou=Com\\,pany", DN.new("cn","Jam<m>y","ou=Com\\,pany").to_s)
+  end
+
+  def test_to_a
+    # Uses each internally, so also tests each
+    assert_equal(["cn","Jam<m>y","ou","Com,pany"], DN.new("cn=Jam\\<m\\>y,ou=Com\\,pany").to_a)
+  end
+end

--- a/test/test_dn.rb
+++ b/test/test_dn.rb
@@ -1,4 +1,5 @@
 require 'common'
+require 'net/ldap/dn'
 
 class TestDN < Test::Unit::TestCase
   DN = Net::LDAP::DN

--- a/test/test_dn.rb
+++ b/test/test_dn.rb
@@ -7,8 +7,18 @@ class TestDN < Test::Unit::TestCase
     assert_equal("cn=Jam\\<m\\>y,ou=Com\\,pany", DN.new("cn","Jam<m>y","ou=Com\\,pany").to_s)
   end
 
+  def test_to_ber
+    # Tests the proxying, as we do not define our own to_ber method in DN
+    assert_equal("\004\031cn=Jam\\<m\\>y,ou=Com\\,pany", DN.new("cn","Jam<m>y","ou=Com\\,pany").to_ber)
+  end
+
   def test_to_a
     # Uses each internally, so also tests each
     assert_equal(["cn","Jam<m>y","ou","Com,pany"], DN.new("cn=Jam\\<m\\>y,ou=Com\\,pany").to_a)
+  end
+
+  def test_entry
+    entry = Net::LDAP::Entry.new(Net::LDAP::DN.new("cn","Jam<m>y","ou=Com\\,pany"))
+    assert_equal("dn: cn=Jam\\<m\\>y,ou=Com\\,pany\n", entry.to_ldif)
   end
 end

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -24,6 +24,13 @@ class TestFilter < Test::Unit::TestCase
     assert_equal("(uid=george *)", Filter.eq("uid", "george *").to_s)
   end
 
+  def test_convenience_filters
+    assert_equal("(uid=\\2a)", Filter.equals("uid", "*").to_s)
+    assert_equal("(uid=\\28*)", Filter.begins("uid", "(").to_s)
+    assert_equal("(uid=*\\29)", Filter.ends("uid", ")").to_s)
+    assert_equal("(uid=*\\5c*)", Filter.contains("uid", "\\").to_s)
+  end
+
 	def test_c2
     assert_equal("(uid=george *)",
                  Filter.from_rfc2254("uid=george *").to_rfc2254)

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -25,10 +25,10 @@ class TestFilter < Test::Unit::TestCase
   end
 
   def test_convenience_filters
-    assert_equal("(uid=\\2a)", Filter.equals("uid", "*").to_s)
+    assert_equal("(uid=\\2A)", Filter.equals("uid", "*").to_s)
     assert_equal("(uid=\\28*)", Filter.begins("uid", "(").to_s)
     assert_equal("(uid=*\\29)", Filter.ends("uid", ")").to_s)
-    assert_equal("(uid=*\\5c*)", Filter.contains("uid", "\\").to_s)
+    assert_equal("(uid=*\\5C*)", Filter.contains("uid", "\\").to_s)
   end
 
 	def test_c2


### PR DESCRIPTION
Hi guys,

Here are some methods for creating filters that are more painless for the developer. They automatically escape their values so are suitable for taking input straight from the user.

I added a test for the methods, which also tests the escaping.

DN's also need escaping in ldap, but I'll probably add a new pull request for that as and when I have something ready.

James.
