### PR TITLE
Paging control

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1386,14 +1386,15 @@ class Net::LDAP::Connection #:nodoc:
         search_attributes.to_ber_sequence
       ].to_ber_appsequence(3)
 
-      controls = [
+      controls = []
+      controls <<
         [
           Net::LDAP::LdapControls::PagedResults.to_ber,
           # Criticality MUST be false to interoperate with normal LDAPs.
           false.to_ber,
           rfc2696_cookie.map{ |v| v.to_ber}.to_ber_sequence.to_s.to_ber
-        ].to_ber_sequence
-      ].to_ber_contextspecific(0)
+        ].to_ber_sequence if paged_searches_supported
+      controls = controls.to_ber_contextspecific(0)
 
       pkt = [next_msgid.to_ber, request, controls].to_ber_sequence
       @conn.write pkt


### PR DESCRIPTION
From the rubyforge patch:
http://rubyforge.org/tracker/index.php?func=detail&aid=28577&group_id=143&atid=633

Only sends a paging control where it is supported. Helps with a server where asking for paging can result in an "Insufficient Access" return, instead of it ignoring paging.

Also discussed here:
http://groups.google.com/group/ruby-ldap/msg/bbdde00c42f3b45d

Needs a server to test, have tested against my live server.
