### PR TITLE
Regexp warning

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -751,7 +751,7 @@ class Net::LDAP::Filter
     # This parses a given expression inside of parentheses.
     def parse_filter_branch(scanner)
       scanner.scan(/\s*/)
-      if token = scanner.scan(/[-\w\d_:.]*[\d\w]/)
+      if token = scanner.scan(/[-\w:.]*[\w]/)
         scanner.scan(/\s*/)
         if op = scanner.scan(/<=|>=|!=|:=|=/)
           scanner.scan(/\s*/)

--- a/spec/unit/ldap/filter_spec.rb
+++ b/spec/unit/ldap/filter_spec.rb
@@ -25,6 +25,7 @@ describe Net::LDAP::Filter do
         '(:dn:2.4.8.10:=Dino)', 
         '(cn:dn:1.2.3.4.5:=John Smith)', 
         '(sn:dn:2.4.6.8.10:=Barbara Jones)', 
+        '(sn:_89:=Barba_ra Jones)', 
       ].each do |filter_str|
         context "from_rfc2254(#{filter_str.inspect})" do
           attr_reader :filter


### PR DESCRIPTION
Patch from:
http://rubyforge.org/tracker/?func=detail&atid=633&aid=28588&group_id=143

Code seems to have moved on since then, so made changes that matched the spirit of the request.

There isn't really a way to make a failing test for it, so I just added an edge case to the spec.
