### PR TITLE
Filter single clauses

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -716,7 +716,7 @@ class Net::LDAP::Filter
       filter = nil
       branches = parse_branches(scanner)
 
-      if branches.size >= 2
+      if branches.size >= 1
         filter = branches.shift
         while not branches.empty?
           filter = filter.__send__(op, branches.shift)

--- a/spec/unit/ldap/filter_spec.rb
+++ b/spec/unit/ldap/filter_spec.rb
@@ -24,7 +24,8 @@ describe Net::LDAP::Filter do
         '(o:dn:=Ace Industry)', 
         '(:dn:2.4.8.10:=Dino)', 
         '(cn:dn:1.2.3.4.5:=John Smith)', 
-        '(sn:dn:2.4.6.8.10:=Barbara Jones)', 
+        '(sn:dn:2.4.6.8.10:=Barbara Jones)',
+        '(&(sn:dn:2.4.6.8.10:=Barbara Jones))'
       ].each do |filter_str|
         context "from_rfc2254(#{filter_str.inspect})" do
           attr_reader :filter

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -45,6 +45,10 @@ class TestFilter < Test::Unit::TestCase
                  Filter.from_rfc2254("(! (mail=*))").to_rfc2254)
 	end
 
+	def test_filter_with_single_clause
+		assert_equal("(cn=name)", Net::LDAP::Filter.construct("(&(cn=name))").to_s)
+    end
+
 	def test_filters_from_ber
 		[
 			Net::LDAP::Filter.eq("objectclass", "*"),
@@ -69,11 +73,11 @@ class TestFilter < Test::Unit::TestCase
 			Net::LDAP::Filter.eq("objectclass", "aaa*"),
 			Net::LDAP::Filter.eq("objectclass", "aaa*bbb*"),
 			Net::LDAP::Filter.eq("objectclass", "aaa*bbb*ccc*"),
-		].each {|ber|
+		].each do |ber|
 			f = Net::LDAP::Filter.parse_ber(ber.to_ber.read_ber(Net::LDAP::AsnSyntax))
 			assert(f == ber)
 			assert_equal(f.to_ber, ber.to_ber)
-		}
+		end
 	end
 
 	def test_ber_from_rfc2254_filter
@@ -102,10 +106,10 @@ class TestFilter < Test::Unit::TestCase
 			Net::LDAP::Filter.construct("objectclass=aaa*"),
 			Net::LDAP::Filter.construct("objectclass=aaa*bbb*"),
 			Net::LDAP::Filter.construct("objectclass=aaa*bbb*ccc*"),
-		].each {|ber|
-		f = Net::LDAP::Filter.parse_ber(ber.to_ber.read_ber(Net::LDAP::AsnSyntax))
+		].each do |ber|
+			f = Net::LDAP::Filter.parse_ber(ber.to_ber.read_ber(Net::LDAP::AsnSyntax))
 			assert(f == ber)
 			assert_equal(f.to_ber, ber.to_ber)
-		}
+		end
 	end
 end


### PR DESCRIPTION
From rubyforge bug:
http://rubyforge.org/tracker/index.php?func=detail&aid=25084&group_id=143&atid=631

Includes spec update, which fails before and passes after the change.
