### PR TITLE
Filter escaping

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -249,12 +249,11 @@ class Net::LDAP::Filter
     # string using a single backslash ('\') as escape. 
     #
     ESCAPES = {
-      '!' => '21', # EXCLAMATION    = %x21 ; exclamation mark ("!")
-      '&' => '26', # AMPERSAND      = %x26 ; ampersand (or AND symbol) ("&")
-      '*' => '2A', # ASTERISK       = %x2A ; asterisk ("*")
-      ':' => '3A', # COLON          = %x3A ; colon (":")
-      '|' => '7C', # VERTBAR        = %x7C ; vertical bar (or pipe) ("|")
-      '~' => '7E', # TILDE          = %x7E ; tilde ("~")
+      "\0" => '00', # NUL            = %x00 ; null character
+      '*'  => '2A', # ASTERISK       = %x2A ; asterisk ("*")
+      '('  => '28', # LPARENS        = %x28 ; left parenthesis ("(")
+      ')'  => '29', # RPARENS        = %x29 ; right parenthesis (")")
+      '\\' => '5C', # ESC            = %x5C ; esc (or backslash) ("\")
     }
     # Compiled character class regexp using the keys from the above hash. 
     ESCAPE_RE = Regexp.new(

--- a/spec/unit/ldap/filter_spec.rb
+++ b/spec/unit/ldap/filter_spec.rb
@@ -76,8 +76,8 @@ describe Net::LDAP::Filter do
     end
   end
   describe "<- .escape(str)" do
-    it "should escape !, &, *, :, | and ~" do
-      Net::LDAP::Filter.escape('!&*:|~').should == "\\21\\26\\2A\\3A\\7C\\7E"
+    it "should escape nul, *, (, ) and \\" do
+      Net::LDAP::Filter.escape("\0*()\\").should == "\\00\\2A\\28\\29\\5C"
     end 
   end
 end

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -24,6 +24,13 @@ class TestFilter < Test::Unit::TestCase
     assert_equal("(uid=george *)", Filter.eq("uid", "george *").to_s)
   end
 
+  def test_convenience_filters
+    assert_equal("(uid=\\2A)", Filter.equals("uid", "*").to_s)
+    assert_equal("(uid=\\28*)", Filter.begins("uid", "(").to_s)
+    assert_equal("(uid=*\\29)", Filter.ends("uid", ")").to_s)
+    assert_equal("(uid=*\\5C*)", Filter.contains("uid", "\\").to_s)	
+  end
+
 	def test_c2
     assert_equal("(uid=george *)",
                  Filter.from_rfc2254("uid=george *").to_rfc2254)


### PR DESCRIPTION
Update to filter the correct characters.

To continue the discussion from the other pull, I think these are the only characters that need escaping in a filter value to avoid injection. They are the only ones in the spec, and the only ones with special meaning in a value.

To be completely injection proof, we be validating the keys. This patch only escapes values.

We don't actually need to escape keys, because they boil down to the characters [A-Za-z0-9-;]. It might be useful to make the filters validate the key, which could be done across all the filters, not just the convenience ones, because they never need escaping, and should always be valid.

Looking at the rfc, we have:
    simple         = attr filtertype assertionvalue
    attr           = attributedescription
                         ; The attributedescription rule is defined in
                         ; Section 2.5 of [RFC4512].

and from 4512:
    attributedescription = attributetype options
      attributetype = oid
      options = _( SEMI option )
      option = 1_keychar

```
oid = descr / numericoid
descr = keystring
keystring = leadkeychar *keychar
  leadkeychar = ALPHA
  keychar = ALPHA / DIGIT / HYPHEN
```
