### PR TITLE
undefined method 'to_ber' for nil:NilClass. Convert unless nil.

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1470,7 +1470,7 @@ class Net::LDAP::Connection #:nodoc:
       # TODO, fix the following line, which gives a bogus error if the
       # opcode is invalid.
       op_1 = { :add => 0, :delete => 1, :replace => 2 }[op.to_sym].to_ber_enumerated
-      modify_ops << [op_1, [attr.to_s.to_ber, Array(values).map { |v| v.to_ber}.to_ber_set].to_ber_sequence].to_ber_sequence
+      modify_ops << [op_1, [attr.to_s.to_ber, Array(values).map { |v| v.to_ber unless v.nil? }.to_ber_set].to_ber_sequence].to_ber_sequence
     }
 
     request = [modify_dn.to_ber,

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -1,0 +1,24 @@
+require 'common'
+
+class TestLDAP < Test::Unit::TestCase
+    def test_modify_ops_delete
+        args = {:operations=>[[:delete, "mail"]]}
+        result = Net::LDAP::Connection.modify_ops(args)
+        expected = ["0\r\n\x01\x010\b\x04\x04mail1\x00"]
+        assert_equal(expected, result)
+    end
+
+    def test_modify_ops_add
+        args = {:operations=>[[:add, "mail", "testuser@example.com"]]}
+        result = Net::LDAP::Connection.modify_ops(args)
+        expected = ["0#\n\x01\x000\x1E\x04\x04mail1\x16\x04\x14testuser@example.com"]
+        assert_equal(expected, result)
+    end
+
+    def test_modify_ops_replace
+        args = {:operations=>[[:replace, "mail", "testuser@example.com"]]}
+        result = Net::LDAP::Connection.modify_ops(args)
+        expected = ["0#\n\x01\x020\x1E\x04\x04mail1\x16\x04\x14testuser@example.com"]
+        assert_equal(expected, result)
+    end
+end


### PR DESCRIPTION
More info in issue [#1](/larstobi/ruby-net-ldap/issues/issue/1) in my fork.

Fixed in commit [aeda402](/larstobi/ruby-net-ldap/commit/aeda402).
