### PR TITLE
A couple of cleanup things

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -10,6 +10,10 @@
       prevent those operators from having problems with the private new.
     * Added Filter.present and Filter.present? aliases for the method
       previously only known as Filter.pres.
+    * Added Filter.escape to escape strings for use in filters, based on
+      rfc4515.
+    * Added Filter.equals, Filter.begins, Filter.ends and Filter.contains,
+      which automatically escape input for use in a filter string.
     * Cleaned up Net::LDAP::Filter::FilterParser to handle branches better.
       Fixed some of the regular expressions to be more canonically defined.
     * Correctly handles single-branch branches.

--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -1,5 +1,4 @@
 # -*- ruby encoding: utf-8 -*-
-# -*- ruby encoding: utf-8 -*-
 
 ##
 # Class Net::LDAP::Filter is used to constrain LDAP searches. An object of


### PR DESCRIPTION
Missing an entry in the history for filter string escaping, which I think is good to promote.

Had an extra utf-8 header on the filter.rb.
