### PR TITLE
Fix encoding in test_snmp.rb

### DIFF
--- a/test/test_snmp.rb
+++ b/test/test_snmp.rb
@@ -1,3 +1,4 @@
+# coding: us-ascii
 # $Id: testsnmp.rb 231 2006-12-21 15:09:29Z blackhedd $
 
 require 'common'


### PR DESCRIPTION
In Ruby 2.0, all files are in UTF8 by default, so the SnmpGetRequest\* variables get transformed into Unicode sequences and tests fail. This PR simply fixes this by using us-ascii coding for this file.
